### PR TITLE
Detect files with no extension

### DIFF
--- a/github.js
+++ b/github.js
@@ -1,6 +1,8 @@
 /* global chrome */
 
 const $ = window.jQuery
+const includes = require('lodash.includes')
+const startswith = require('lodash.startswith')
 
 const python = require('./languages/python').process
 const javascript = require('./languages/javascript').process
@@ -108,8 +110,41 @@ function main () {
     case 'md':
     case 'mdwn':
     case 'markdown':
-    default:
       markdown()
+      break
+    default:
+      let command = $('.blob-code-inner').first().text()
+      if (!startswith(command, '#!')) {
+        markdown()
+      } else if (includes(command, 'run-cargo-script')) {
+        rust()
+      } else if (includes(command, 'runhaskell')) {
+        haskell()
+      } else if (includes(command, 'crystal')) {
+        crystal()
+      } else if (includes(command, 'python')) {
+        python()
+      } else if (includes(command, 'ruby')) {
+        ruby()
+      } else if (includes(command, 'node')) {
+        node()
+      } else if (includes(command, 'dart')) {
+        dart()
+      } else if (includes(command, 'nim')) {
+        nim()
+      } else if (includes(command, 'go')) {
+        go()
+      } else if (includes(command, 'elm-')) {
+        elm()
+      } else if (includes(command, 'julia')) {
+        julia()
+      // TODO: } else if (includes(command, 'pulp?')) { ?
+      //  purescript()
+      // TODO: } else if (includes(command, 'c?')) { ?
+      //   c()
+      } else {
+        markdown()
+      }
   }
 
   $(document).pjax('a.module-linker', '#js-repo-pjax-container', {timeout: 6000})

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "delay": "^1.3.1",
     "lodash.endswith": "^4.0.0",
+    "lodash.includes": "^4.0.0",
     "lodash.startswith": "^4.0.0",
     "resolve-pathname": "^2.0.2",
     "xtend": "^4.0.1"


### PR DESCRIPTION
Here's my initial attempt at #22.

Feel free to pull in and then add to, extend, or clean up by extracting check functions now that there's two methods. There's two TODOs--c and purescript--I don't really plan to get to those.

Notes
- This executes only *after* no file extensions were matched (extensions still take precedence)
- I included all supported script languages and left out the declarative ones (Markdown, JSON, dependency files, etc), since they have nothing to run them AFAIK
- It only checks for `#!` and common program names to keep it flexible (since not everyone will use `#!/usr/bin/env`)
- As a sort of naive conflict resolution, the if statements are sorted by program name length
- This still defaults to `markdown` like it did before

References
- https://stackoverflow.com/questions/41322300/how-to-execute-rust-code-directly-on-unix-systems-using-the-shebang
- https://github.com/nim-lang/Nim/issues/3301
- https://github.com/crystal-lang/crystal/issues/546
- https://stackoverflow.com/questions/7707178/whats-the-appropriate-go-shebang-line
- https://stackoverflow.com/questions/25880705/when-writing-a-haskell-script-get-syntax-error-near-unexpected-token
- https://stackoverflow.com/questions/29718123/cabal-vs-runhaskell-when-to-use
- https://guide.elm-lang.org/install.html
