### PR TITLE
Fix broken images

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <head>
         <title>Module Linker, a browser extension that improves your life!</title>
 
-        <link rel="shortcut icon" href="icon48.png" />
-        <meta property="og:image" content="icon128.png" />
+        <link rel="shortcut icon" href="https://raw.githubusercontent.com/fiatjaf/module-linker/master/icon48.png" />
+        <meta property="og:image" content="https://raw.githubusercontent.com/fiatjaf/module-linker/master/icon128.png" />
 
         <meta charset="UTF-8" />
 
@@ -16,7 +16,7 @@
         <h1>Module Linker, a browser extension for browsing source code better</h1>
 
         <div>
-            <img src="icon128.png" alt="Module Linker logo" />
+            <img src="https://raw.githubusercontent.com/fiatjaf/module-linker/master/icon128.png" alt="Module Linker logo" />
         </div>
         <br />
         <div>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <head>
         <title>Module Linker, a browser extension that improves your life!</title>
 
-        <link rel="shortcut icon" href="https://raw.githubusercontent.com/fiatjaf/module-linker/master/icon48.png" />
-        <meta property="og:image" content="https://raw.githubusercontent.com/fiatjaf/module-linker/master/icon128.png" />
+        <link rel="shortcut icon" href="https://rawcdn.githack.com/fiatjaf/module-linker/d5d9adc/icon48.png" />
+        <meta property="og:image" content="https://rawcdn.githack.com/fiatjaf/module-linker/d5d9adc/icon128.png" />
 
         <meta charset="UTF-8" />
 
@@ -16,7 +16,7 @@
         <h1>Module Linker, a browser extension for browsing source code better</h1>
 
         <div>
-            <img src="https://raw.githubusercontent.com/fiatjaf/module-linker/master/icon128.png" alt="Module Linker logo" />
+            <img src="https://rawcdn.githack.com/fiatjaf/module-linker/d5d9adc/icon128.png" alt="Module Linker logo" />
         </div>
         <br />
         <div>


### PR DESCRIPTION
This fixes broken images on the website.

In my PR #48, I replaced RawGit URLs with relative ones (because it will shut down). But some icons are stored in the `master` branch so the images became broken.

I now replaced all broken URLs with link to `https://raw.githubusercontent.com/fiatjaf/module-linker/master/` which should correctly link them to the `master` branch.