### PR TITLE
Better support for PHP

### DIFF
--- a/github.js
+++ b/github.js
@@ -93,6 +93,9 @@ function main () {
     case 'yaml':
       require('./languages/yaml').process()
       break
+    case 'php':
+      require('./languages/php').process()
+      break
     // css
     // scss
     // sass
@@ -100,7 +103,6 @@ function main () {
     // stylus
     // ocaml'
     // lua
-    // php
     case 'text':
       require('./languages/text').process()
       break

--- a/languages/json.js
+++ b/languages/json.js
@@ -101,24 +101,12 @@ function packagejson () {
       depsOpen = true
     }
 
-    if (line.match('}')) {
-      depsOpen = false
-    }
-
     if (line.match(/"contributors"/) || line.match(/"authors"/)) {
       contributorsOpen = true
     }
 
-    if (line.match(']')) {
-      contributorsOpen = false
-    }
-
     if (line.match(/"author"/) && line.match('{')) {
       authorOpen = true
-    }
-
-    if (line.match('}')) {
-      authorOpen = false
     }
 
     if (line.match(/"bin"/) && line.match('{')) {
@@ -126,7 +114,13 @@ function packagejson () {
     }
 
     if (line.match('}')) {
+      depsOpen = false
+      authorOpen = false
       binOpen = false
+    }
+
+    if (line.match(']')) {
+      contributorsOpen = false
     }
 
     if (depsOpen && elem.find('.pl-s').length === 2) {

--- a/languages/json.js
+++ b/languages/json.js
@@ -88,7 +88,7 @@ function packagejson () {
       lineWithUrlFetcher(elem, npmurl)
     }
 
-    if (!contributorsOpen && !authorOpen && line.match(/"name":/)) {
+    if (!contributorsOpen && !authorOpen && line.match(/"name"\s*:/)) {
       let name = elem.find('.pl-s').eq(1).text().trim().slice(1, -1)
       let url = 'https://npmjs.com/package/' + name
       createLink(rawelem, name, {url, kind: 'maybe'})
@@ -100,12 +100,12 @@ function packagejson () {
       createLink(rawelem, main, url)
     }
 
-    if (line.match(/"main":/) || line.match(/"module":/) || line.match(/"es2015":/) || line.match(/"esnext":/) || // Files for different Node.js versions
-        (line.match(/"browser":/) && !line.match(/"browser": {/)) || line.match(/"web":/) || // Files for web browsers
-        line.match(/"unpkg":/) || line.match(/"jsdelivr":/) || line.match(/"runkitExampleFilename":/) || // Files for popular CDNs and examples
-        line.match(/"source":/) || line.match(/"src":/) || line.match(/"typings":/) || line.match(/"types":/) || // Files for sources and typings
-        line.match(/"node":/) || line.match(/"deno":/) || // Files for different runtimes
-        (line.match(/"bin":/) && !line.match(/"bin": {/)) // Executable file
+    if (line.match(/"main"\s*:/) || line.match(/"module"\s*:/) || line.match(/"es2015"\s*:/) || line.match(/"esnext"\s*:/) || // Files for different Node.js versions
+        (line.match(/"browser"\s*:/) && !line.match(/"browser"\s*:\s*{/)) || line.match(/"web"\s*:/) || // Files for web browsers
+        line.match(/"unpkg"\s*:/) || line.match(/"jsdelivr"\s*:/) || line.match(/"runkitExampleFilename"\s*:/) || // Files for popular CDNs and examples
+        line.match(/"source"\s*:/) || line.match(/"src"\s*:/) || line.match(/"typings"\s*:/) || line.match(/"types"\s*:/) || // Files for sources and typings
+        line.match(/"node"\s*:/) || line.match(/"deno"\s*:/) || // Files for different runtimes
+        (line.match(/"bin"\s*:/) && !line.match(/"bin"\s*:\s*{/)) // Executable file
     ) {
       let main = elem.find('.pl-s').eq(1).text().trim().slice(1, -1)
       let url = resolve(main, location.pathname)

--- a/languages/json.js
+++ b/languages/json.js
@@ -23,6 +23,8 @@ function composerjson () {
   var depsOpen = false
   var authorsOpen = false
   var binOpen = false
+  var psrOpen = false
+  var filesOpen = false
 
   $('.blob-code-inner').each((_, rawelem) => {
     let elem = $(rawelem)
@@ -33,24 +35,31 @@ function composerjson () {
       depsOpen = true
     }
 
-    if (line.match('}')) {
-      depsOpen = false
-    }
-
     if (line.match(/"authors"/)) {
       authorsOpen = true
-    }
-
-    if (line.match(']')) {
-      authorsOpen = false
     }
 
     if (line.match(/"bin"/)) {
       binOpen = true
     }
 
+    if (line.match(/"psr-0"/) || line.match(/"psr-4"/)) {
+      psrOpen = true
+    }
+
+    if (line.match(/"classmap"/) || line.match(/"files"/)) {
+      filesOpen = true
+    }
+
+    if (line.match('}')) {
+      depsOpen = false
+      psrOpen = false
+    }
+
     if (line.match(']')) {
+      authorsOpen = false
       binOpen = false
+      filesOpen = false
     }
 
     if (depsOpen && elem.find('.pl-s').length === 2) {
@@ -63,8 +72,14 @@ function composerjson () {
       createLink(rawelem, name, {url, kind: 'maybe'})
     }
 
-    if (binOpen && line.split(':').length == 1) {
+    if ((binOpen || filesOpen) && line.split(':').length == 1) {
       let main = elem.find('.pl-s').eq(0).text().trim().slice(1, -1)
+      let url = resolve(main, location.pathname)
+      createLink(rawelem, main, url)
+    }
+
+    if (psrOpen && line.match(/".*"\s?/)) {
+      let main = elem.find('.pl-s').eq(1).text().trim().slice(1, -1)
       let url = resolve(main, location.pathname)
       createLink(rawelem, main, url)
     }

--- a/languages/json.js
+++ b/languages/json.js
@@ -66,7 +66,7 @@ function composerjson () {
       lineWithUrlFetcher(elem, composerurl)
     }
 
-    if (!authorsOpen && line.match(/"name"\s?:/)) {
+    if (!authorsOpen && line.match(/"name"\s*:/)) {
       let name = elem.find('.pl-s').eq(1).text().trim().slice(1, -1)
       let url = 'https://packagist.org/packages/' + name
       createLink(rawelem, name, {url, kind: 'maybe'})

--- a/languages/php.js
+++ b/languages/php.js
@@ -1,4 +1,107 @@
+const resolve = require('resolve-pathname')
+
 const external = require('../helpers').external
+const treePromise = require('../helpers').treePromise
+const createLink = require('../helpers').createLink
+const htmlWithLink = require('../helpers').htmlWithLink
+const bloburl = require('../helpers').bloburl
+const treeurl = require('../helpers').treeurl
+
+const extensions = ['php', 'phtml']
+
+module.exports.process = process
+function process () {
+  let { current } = window.pathdata
+
+  $('.blob-code-inner').each((_, elem) => {
+    let line = elem.innerText.trim()
+    processLine(elem, line, current.join('/'))
+  })
+}
+
+module.exports.processLine = processLine
+function processLine (elem, line, currentPath, lineIndex) {
+  let moduleName
+
+  let names = [
+    /require +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /require +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
+    /require_once +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /require_once +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
+    /include +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /include +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
+    /include_once +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /include_once +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
+  ]
+    .filter(x => x)
+    .map(regex => regex[1])
+
+  if (names.length) {
+    moduleName = names[0]
+  } else {
+    return
+  }
+
+  Promise.resolve()
+  .then(() => {
+    return typeof lineIndex === 'undefined'
+      ? treePromise()
+        .then(paths => {
+          for (let i = 0; i < paths.length; i++) {
+            let path = paths[i]
+
+            // ignore paths ending in anything but one of our extensions
+            if (extensions.indexOf(path.split('.').slice(-1)[0]) === -1) {
+              continue
+            }
+
+            let module
+            if (moduleName.charAt(0) === '/') {
+              module = moduleName.substr(1)
+            } else {
+              module = moduleName
+            }
+
+            let resolved = resolve(module, currentPath)
+            if (path === resolved) {
+              let { user, repo, ref } = window.pathdata
+              return bloburl(user, repo, ref, path)
+            }
+          }
+
+          throw new Error('fallback')
+        })
+        .catch(() => {
+          let {user, repo, ref} = window.pathdata
+          let module
+
+          if (moduleName.charAt(0) === '/') {
+            module = moduleName.substr(1)
+          } else {
+            module = moduleName
+          }
+
+          return {
+            url: bloburl(user, repo, ref, resolve(module, currentPath)),
+            kind: 'maybe'
+          }
+        })
+      : null
+  })
+  .then(url => {
+    if (typeof lineIndex !== 'undefined') {
+      // lineIndex is passed from markdown.js, meaning we must replace
+      // only in that line -- in this case `elem` is the whole code block,
+      // not, as normally, a single line
+      let lines = elem.innerHTML.split('\n')
+      lines[lineIndex] = htmlWithLink(lines[lineIndex], moduleName, url, true)
+      elem.innerHTML = lines.join('\n')
+      return
+    }
+
+    createLink(elem, moduleName, url, true)
+  })
+}
 
 module.exports.composerurl = composerurl
 function composerurl (moduleName) {

--- a/languages/php.js
+++ b/languages/php.js
@@ -24,13 +24,13 @@ function processLine (elem, line, currentPath, lineIndex) {
   let moduleName
 
   let names = [
-    /require +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /require+(?: __DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
     /require +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
-    /require_once +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /require_once+(?: __DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
     /require_once +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
-    /include +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /include+(?: __DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
     /include +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
-    /include_once +(?:__DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
+    /include_once+(?: __DIR__ *\. *)? *\(['"]([^)]+)['"]\);/.exec(line),
     /include_once +(?:__DIR__ *\. *)? *['"]([^)]+)['"];/.exec(line),
   ]
     .filter(x => x)

--- a/languages/php.js
+++ b/languages/php.js
@@ -2,12 +2,24 @@ const external = require('../helpers').external
 
 module.exports.composerurl = composerurl
 function composerurl (moduleName) {
-  if (moduleName.split('/').length === 1) {
-    // composer packages are like `user-or-project/package`.
-    // but sometimes there seems to be a random `php` required on composer.json.
+  if (moduleName === 'php') {
+    // package requires specific PHP version
+    // ignore this when parsing
     return Promise.reject()
   }
 
+  if (moduleName.startsWith('ext-') && moduleName.split('/').length === 1) {
+    // package require specific PHP extension
+    // link it to PHP documentation website
+    let ext = moduleName.split('-')[1].toLowerCase()
+    return Promise.resolve({
+      url: `https://www.php.net/manual/en/book.${ext}.php`,
+      kind: 'stdlib'
+    })
+  }
+
+  // package require normal Composer package
+  // link it to Packagist
   return external('composer', moduleName)
     .catch(() => ({
       url: `https://packagist.org/packages/${moduleName}`,


### PR DESCRIPTION
I created better support for PHP. This fixes #46.

Unfortunately, I wasn't able to link `use` statements. This could maybe be done with some external API, so if I find (or create) it, I will create another PR.

Changes in this PR related to PHP:

* Support for parsing PHP extensions (link `ext-*` dependency to documentation) in `compsoer.json`
* Support for linking `name` and `bin` fields in `compsoer.json`
* Support for linking PHP's `include` and `require`

Other changes:

* Allow multiple spaces between key and colon in JSON
* Merge similar code in JSON parser
