### PR TITLE
Use more generic container selector

### DIFF
--- a/github.js
+++ b/github.js
@@ -1,11 +1,14 @@
 /* global chrome */
 
+const PJAX_CONTAINER_SELECTOR = 'main'
+
 const $ = window.jQuery
 
 function main () {
   // this global check will prevent us from running process() multiple times.
   if ($('#module-linker-done').length) return
   $('#js-repo-pjax-container').append($('<span id="module-linker-done">'))
+  $(PJAX_CONTAINER_SELECTOR).append($('<span id="module-linker-done">'))
 
   let path = location.pathname.split('/')
   window.pathdata = {
@@ -110,6 +113,7 @@ function main () {
 
   // setup pjax
   $(document).pjax('a.module-linker', '#js-repo-pjax-container', {timeout: 0})
+  $(document).pjax('a.module-linker', PJAX_CONTAINER_SELECTOR, {timeout: 0})
   $(document).on('pjax:timeout', function (e) {
     e.preventDefault()
   })


### PR DESCRIPTION
It seems that Github does not always add the ID to `main`, but the `main` is always there.

Fixes #55